### PR TITLE
Add explicit struct for Id

### DIFF
--- a/rusty_pizza_server/src/order_model/special.rs
+++ b/rusty_pizza_server/src/order_model/special.rs
@@ -1,3 +1,4 @@
+use crate::util::id::Id;
 use crate::util::id_provider::IdProvider;
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -17,19 +18,19 @@ impl SpecialFactory {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Special {
-    id: u32,
+    id: Id,
     description: String,
 }
 
 impl Special {
-    pub fn new(id: u32, description: String) -> Special {
+    pub fn new(id: Id, description: String) -> Special {
         Special { id, description }
     }
 
-    pub fn get_id(&self) -> u32 {
-        self.id
+    pub fn get_id(&self) -> Id {
+        self.id.clone()
     }
 
     pub fn get_description(&self) -> String {
@@ -48,13 +49,13 @@ mod tests {
     #[test]
     fn special_can_be_created() {
         // When:
-        let special = Special::new(0, String::from("Käserand"));
+        let special = Special::new(Id::new(0), String::from("Käserand"));
 
         // Then:
         assert_eq!(
             special,
             Special {
-                id: 0,
+                id: Id::new(0),
                 description: String::from("Käserand")
             }
         );
@@ -72,7 +73,7 @@ mod tests {
         assert_eq!(
             special,
             Special {
-                id: 0,
+                id: Id::new(0),
                 description: String::from("Käserand")
             }
         );

--- a/rusty_pizza_server/src/order_model/user.rs
+++ b/rusty_pizza_server/src/order_model/user.rs
@@ -1,11 +1,18 @@
+use crate::util::id::Id;
+
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct User {
+    id: Id,
     name: String,
 }
 
 impl User {
-    pub fn new(name: String) -> User {
-        User { name }
+    pub fn new(id: Id, name: String) -> User {
+        User { id, name }
+    }
+
+    pub fn get_id(&self) -> Id {
+        self.id.clone()
     }
 
     pub fn get_name(&self) -> &String {
@@ -20,11 +27,15 @@ mod tests {
     #[test]
     fn user_can_be_created() {
         //Given
+        let id = Id::new(42);
         let str_name = "Peter";
         let name = String::from(str_name);
+
         //When
-        let user = User::new(name);
+        let user = User::new(id.clone(), name);
+
         //Then
+        assert_eq!(id, user.get_id());
         assert_eq!(str_name, user.get_name());
     }
 }

--- a/rusty_pizza_server/src/util/id.rs
+++ b/rusty_pizza_server/src/util/id.rs
@@ -1,5 +1,5 @@
 /// A usually unique ID referencing an entity.
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Id {
     value: u32,
 }

--- a/rusty_pizza_server/src/util/id.rs
+++ b/rusty_pizza_server/src/util/id.rs
@@ -1,0 +1,26 @@
+/// A usually unique ID referencing an entity.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct Id {
+    value: u32,
+}
+
+impl Id {
+    pub fn new(value: u32) -> Id {
+        Id { value }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ids_with_equal_value_are_equal() {
+        // When:
+        let id1 = Id::new(0);
+        let id2 = Id::new(0);
+
+        // Then:
+        assert_eq!(id1, id2);
+    }
+}

--- a/rusty_pizza_server/src/util/id_provider.rs
+++ b/rusty_pizza_server/src/util/id_provider.rs
@@ -1,3 +1,5 @@
+use crate::util::id::Id;
+
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct IdProvider {
     next_id: u32,
@@ -8,10 +10,10 @@ impl IdProvider {
         IdProvider { next_id: 0 }
     }
 
-    pub fn generate_next(&mut self) -> u32 {
+    pub fn generate_next(&mut self) -> Id {
         let next = self.next_id;
         self.next_id = next + 1;
-        next
+        Id::new(next)
     }
 }
 
@@ -28,7 +30,7 @@ mod tests {
         let id = id_provider.generate_next();
 
         // Then:
-        assert_eq!(id, 0);
+        assert_eq!(id, Id::new(0));
     }
 
     #[test]
@@ -41,6 +43,6 @@ mod tests {
         let id = id_provider.generate_next();
 
         // Then:
-        assert_eq!(id, 1);
+        assert_eq!(id, Id::new(1));
     }
 }

--- a/rusty_pizza_server/src/util/mod.rs
+++ b/rusty_pizza_server/src/util/mod.rs
@@ -1,3 +1,4 @@
 pub mod errors;
+pub mod id;
 pub mod id_provider;
 pub mod money;


### PR DESCRIPTION
Adds an explicit struct representing IDs, users are now forced to have an `Id`. Closes #16.